### PR TITLE
Support document context with user prompts

### DIFF
--- a/ia_provider/exporter.py
+++ b/ia_provider/exporter.py
@@ -210,7 +210,9 @@ def generer_export_docx(
 
     ``styles_interface`` correspond aux styles définis dans l'interface.
     ``template_source`` peut contenir des styles extraits d'un document importé
-    et est prioritaire sur ``styles_interface`` lorsqu'il est fourni.
+    et est prioritaire sur ``styles_interface`` lorsqu'il est fourni. Lorsque
+    ``template_source`` est ``None``, les styles de l'interface servent de
+    solution de repli.
 
     Chaque résultat doit contenir au minimum les champs ``status``,
     ``prompt_text`` et ``clean_response`` (ou ``response``).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+# Core dependencies
 streamlit
 openai
 anthropic
-python-docx
+python-docx  # DOCX processing
 markdown
 beautifulsoup4
 lxml
-PyMuPDF
+PyMuPDF  # PDF processing


### PR DESCRIPTION
## Summary
- Allow combining a user-provided instruction with an optional uploaded document
- Warn when document styles can't be detected and fall back to Markdown
- Clarify exporter styling fallback and document import dependencies

## Testing
- `python -m py_compile app.py ia_provider/exporter.py ia_provider/importer.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ade4b60508832bb07414c3083304fb