### PR TITLE
Refactor DOCX analysis to return structured blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -433,7 +433,12 @@ prompt_final = user_instruction
 prompt_text = user_instruction
 
 if uploaded_file is not None:
-    texte_a_traiter, template_styles = importer.analyser_document(uploaded_file)
+    contenu_structure, template_styles = importer.analyser_document(uploaded_file)
+    texte_a_traiter = (
+        "\n".join(block["text"] for block in contenu_structure)
+        if isinstance(contenu_structure, list)
+        else contenu_structure
+    )
     st.session_state.source_template_styles = template_styles
     prompt_final = (
         "Voici une instruction à appliquer sur le contenu d'un document.\n\n"


### PR DESCRIPTION
## Summary
- Refactor `analyser_docx` to output structured content blocks with heading level detection
- Allow `analyser_document` to return either structured blocks or plain text
- Update app to handle structured DOCX content and rebuild text for prompts

## Testing
- `python -m py_compile app.py ia_provider/importer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ae1f71d6f8832ba079a386ec43a79d